### PR TITLE
message hydration; prompt caching and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+
+## [0.2.4] - 2024-11-06
+
+### Changed
+
 - set apiUseTls to false during project init if certs could not be created
 - fixed message hydration to keep last two versions of each file
 - changed prompt caching to add cache points of three most recent messages with hydrated files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- set apiUseTls to false during project init if certs could not be created
+- fixed message hydration to keep last two versions of each file
+- changed prompt caching to add cache points of three most recent messages with hydrated files
+- removed "statement objective" on first statement, in favour of "conversation objective"
+- fixed statement counts in messages.jsonl
 
 
 ## [0.2.3] - 2024-11-03

--- a/api/deno.jsonc
+++ b/api/deno.jsonc
@@ -16,9 +16,7 @@
 		"update-deps": "deno cache src/main.ts && deno cache tests/deps.ts"
 	},
 	"importMap": "../import_map.json",
-	"unstable": [
-		"kv"
-	],
+	"unstable": ["kv"],
 	"fmt": {
 		"useTabs": true,
 		"lineWidth": 120,
@@ -26,26 +24,15 @@
 		"semiColons": true,
 		"singleQuote": true,
 		"proseWrap": "preserve",
-		"include": [
-			"src/",
-			"tests/"
-		],
-		"exclude": [
-			"src/testdata/",
-			"src/fixtures/**/*.ts"
-		]
+		"include": ["src/", "tests/"],
+		"exclude": ["src/testdata/", "src/fixtures/**/*.ts"]
 	},
 	"lint": {
 		"files": {
-			"include": [
-				"tests/pipelineProvider.js"
-			]
+			"include": ["tests/pipelineProvider.js"]
 		},
 		"rules": {
-			"exclude": [
-				"require-await",
-				"no-var"
-			]
+			"exclude": ["require-await", "no-var"]
 		}
 	}
 }

--- a/api/deno.jsonc
+++ b/api/deno.jsonc
@@ -1,6 +1,6 @@
 {
 	"name": "bb-api",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"exports": "./src/main.ts",
 	"tasks": {
 		"start": "deno run --allow-read --allow-write --allow-run --allow-net --allow-env src/main.ts",
@@ -16,7 +16,9 @@
 		"update-deps": "deno cache src/main.ts && deno cache tests/deps.ts"
 	},
 	"importMap": "../import_map.json",
-	"unstable": ["kv"],
+	"unstable": [
+		"kv"
+	],
 	"fmt": {
 		"useTabs": true,
 		"lineWidth": 120,
@@ -24,15 +26,26 @@
 		"semiColons": true,
 		"singleQuote": true,
 		"proseWrap": "preserve",
-		"include": ["src/", "tests/"],
-		"exclude": ["src/testdata/", "src/fixtures/**/*.ts"]
+		"include": [
+			"src/",
+			"tests/"
+		],
+		"exclude": [
+			"src/testdata/",
+			"src/fixtures/**/*.ts"
+		]
 	},
 	"lint": {
 		"files": {
-			"include": ["tests/pipelineProvider.js"]
+			"include": [
+				"tests/pipelineProvider.js"
+			]
 		},
 		"rules": {
-			"exclude": ["require-await", "no-var"]
+			"exclude": [
+				"require-await",
+				"no-var"
+			]
 		}
 	}
 }

--- a/api/src/llms/llmMessage.ts
+++ b/api/src/llms/llmMessage.ts
@@ -5,6 +5,7 @@ import type {
 	LLMProviderMessageResponseType,
 	LLMTokenUsage,
 } from 'api/types.ts';
+import type { ConversationMetrics } from 'shared/types.ts';
 import type { LLMToolInputSchema } from 'api/llms/llmTool.ts';
 
 export interface LLMMessageContentPartTextBlock {
@@ -91,15 +92,22 @@ export interface LLMMessageProviderResponse {
 class LLMMessage {
 	public timestamp: string = new Date().toISOString();
 	public id!: string;
+
+	public _conversationTurnCount!: number;
+	public _statementTurnCount!: number;
+	public _statementCount!: number;
+
 	constructor(
 		public role: 'user' | 'assistant' | 'system' | 'tool', // system and tool are only for openai
 		public content: LLMMessageContentParts,
+		stats: ConversationMetrics,
 		public tool_call_id?: string,
 		public providerResponse?: LLMMessageProviderResponse,
 		id?: string,
 	) {
 		this.setId(id);
 		this.setTimestamp();
+		this.conversationStats = stats;
 	}
 
 	public setId(id?: string): void {
@@ -108,6 +116,20 @@ class LLMMessage {
 		} else if (!this.id) {
 			this.id = ulid();
 		}
+	}
+
+	public get conversationStats(): ConversationMetrics {
+		return {
+			statementCount: this._statementCount,
+			statementTurnCount: this._statementTurnCount,
+			conversationTurnCount: this._conversationTurnCount,
+		};
+	}
+
+	public set conversationStats(stats: ConversationMetrics) {
+		this._statementCount = stats.statementCount;
+		this._statementTurnCount = stats.statementTurnCount;
+		this._conversationTurnCount = stats.conversationTurnCount;
 	}
 
 	public setTimestamp(): void {

--- a/api/src/llms/tools/conversationSummary.tool/tests/tool.test.ts
+++ b/api/src/llms/tools/conversationSummary.tool/tests/tool.test.ts
@@ -5,6 +5,7 @@ import LLMToolConversationSummary from '../tool.ts';
 import type { LLMAnswerToolUse } from 'api/llms/llmMessage.ts';
 import { getProjectEditor, getToolManager, withTestProject } from 'api/tests/testSetup.ts';
 import LLMMessage from 'api/llms/llmMessage.ts';
+import type { ConversationMetrics } from 'shared/types.ts';
 
 // Mock functions
 const mockSaveConversation = async () => {};
@@ -25,6 +26,14 @@ const mockEnsureDir = async () => {};
 // fs.ensureDir = mockEnsureDir;
 
 let copiedFiles: { src: string; dest: string }[] = [];
+
+function incrementConversationStats(conversationStats: ConversationMetrics) {
+	return {
+		statementCount: conversationStats.statementCount++,
+		statementTurnCount: conversationStats.statementTurnCount++,
+		conversationTurnCount: conversationStats.conversationTurnCount++,
+	};
+}
 
 /*
 Deno.test({
@@ -47,12 +56,17 @@ Deno.test({
 			};
 
 			// Mock conversation messages
+			const conversationStats = {
+				statementCount: 0,
+				statementTurnCount: 0,
+				conversationTurnCount: 0,
+			}
 			const mockMessages = [
-				new LLMMessage('user', 'Hello', { usage: { totalTokens: 10 } }),
-				new LLMMessage('assistant', 'Hi there!', { usage: { totalTokens: 15 } }),
-				new LLMMessage('user', 'How are you?', { usage: { totalTokens: 20 } }),
-				new LLMMessage('assistant', "I'm doing well, thank you!", { usage: { totalTokens: 25 } }),
-				new LLMMessage('tool', 'Some tool usage', { usage: { totalTokens: 30 } }),
+				new LLMMessage('user', 'Hello', incrementConversationStats(conversationStats), { usage: { totalTokens: 10 } }),
+				new LLMMessage('assistant', 'Hi there!', incrementConversationStats(conversationStats), { usage: { totalTokens: 15 } }),
+				new LLMMessage('user', 'How are you?', incrementConversationStats(conversationStats), { usage: { totalTokens: 20 } }),
+				new LLMMessage('assistant', "I'm doing well, thank you!", incrementConversationStats(conversationStats), { usage: { totalTokens: 25 } }),
+				new LLMMessage('tool', 'Some tool usage', incrementConversationStats(conversationStats), { usage: { totalTokens: 30 } }),
 			];
 
 			const mockConversation = {
@@ -103,12 +117,17 @@ Deno.test({
 			};
 
 			// Mock conversation messages
+			const conversationStats = {
+				statementCount: 0,
+				statementTurnCount: 0,
+				conversationTurnCount: 0,
+			}
 			const mockMessages = [
-				new LLMMessage('user', 'Hello', { usage: { totalTokens: 10 } }),
-				new LLMMessage('assistant', 'Hi there!', { usage: { totalTokens: 15 } }),
-				new LLMMessage('user', 'How are you?', { usage: { totalTokens: 20 } }),
-				new LLMMessage('assistant', "I'm doing well, thank you!", { usage: { totalTokens: 25 } }),
-				new LLMMessage('tool', 'Some tool usage', { usage: { totalTokens: 30 } }),
+				new LLMMessage('user', 'Hello', incrementConversationStats(conversationStats), { usage: { totalTokens: 10 } }),
+				new LLMMessage('assistant', 'Hi there!', incrementConversationStats(conversationStats), { usage: { totalTokens: 15 } }),
+				new LLMMessage('user', 'How are you?', incrementConversationStats(conversationStats), { usage: { totalTokens: 20 } }),
+				new LLMMessage('assistant', "I'm doing well, thank you!", incrementConversationStats(conversationStats), { usage: { totalTokens: 25 } }),
+				new LLMMessage('tool', 'Some tool usage', incrementConversationStats(conversationStats), { usage: { totalTokens: 30 } }),
 			];
 
 			const mockLLMProvider = {
@@ -180,9 +199,14 @@ Deno.test({
 			};
 
 			// Mock conversation messages
+			const conversationStats = {
+				statementCount: 0,
+				statementTurnCount: 0,
+				conversationTurnCount: 0,
+			}
 			const mockMessages = [
-				new LLMMessage('user', 'Hello', { usage: { totalTokens: 10 } }),
-				new LLMMessage('assistant', 'Hi there!', { usage: { totalTokens: 15 } }),
+				new LLMMessage('user', 'Hello', incrementConversationStats(conversationStats), { usage: { totalTokens: 10 } }),
+				new LLMMessage('assistant', 'Hi there!', incrementConversationStats(conversationStats), { usage: { totalTokens: 15 } }),
 			];
 
 			const mockLLMProvider = {

--- a/api/src/llms/tools/rewriteFile.tool/info.json
+++ b/api/src/llms/tools/rewriteFile.tool/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "rewrite_file",
-	"description": "Completely replaces an existing file's contents or creates a new file. Use with caution as this overwrites the entire file. For partial changes, prefer search_and_replace.",
+	"description": "Completely replaces an existing file's contents or creates a new file. Use with caution as this overwrites the entire file. Always check existing file contents before using this tool. For partial changes, prefer search_and_replace.",
 	"version": "1.0.0",
 	"category": "FileManipulation",
 	"author": "BB Team",

--- a/api/src/llms/tools_manifest.ts
+++ b/api/src/llms/tools_manifest.ts
@@ -202,7 +202,7 @@ export const CORE_TOOLS: Array<CoreTool> = [
 		'metadata': {
 			'name': 'rewrite_file',
 			'description':
-				"Completely replaces an existing file's contents or creates a new file. Use with caution as this overwrites the entire file. For partial changes, prefer search_and_replace.",
+				"Completely replaces an existing file's contents or creates a new file. Use with caution as this overwrites the entire file. Always check existing file contents before using this tool. For partial changes, prefer search_and_replace.",
 			'version': '1.0.0',
 			'category': 'FileManipulation',
 			'author': 'BB Team',

--- a/api/src/storage/conversationPersistence.ts
+++ b/api/src/storage/conversationPersistence.ts
@@ -191,13 +191,13 @@ class ConversationPersistence {
 			await this.saveProjectInfo(this.projectEditor.projectInfo);
 
 			// Save messages
-			const statementCount = conversation.statementCount || 0; // Assuming this property exists
+			//const statementCount = conversation.statementCount || 0; // Assuming this property exists
 			const messages = conversation.getMessages();
-			const messagesContent = messages.map((m) => {
+			const messagesContent = messages.map((m, idx) => {
 				if (m && typeof m === 'object') {
 					return JSON.stringify({
-						statementCount,
-						statementTurnCount: conversation.statementTurnCount,
+						idx,
+						conversationStats: m.conversationStats,
 						role: m.role,
 						content: m.content,
 						id: m.id,

--- a/api/tests/t/conversationInteraction.test.ts
+++ b/api/tests/t/conversationInteraction.test.ts
@@ -5,6 +5,7 @@ import LLMConversationInteraction from '../../src/llms/interactions/conversation
 import LLMMessage, { LLMMessageContentPart, LLMMessageContentPartTextBlock } from 'api/llms/llmMessage.ts';
 import { GitUtils } from 'shared/git.ts';
 import { LLMCallbackType } from 'api/types.ts';
+import type { ConversationMetrics } from 'shared/types.ts';
 import { getProjectEditor, withTestProject } from '../lib/testSetup.ts';
 
 // Mock LLM class
@@ -33,6 +34,14 @@ async function setupTestEnvironment(projectRoot: string) {
 	return { projectEditor, conversation, projectRoot, testFiles };
 }
 
+function incrementConversationStats(conversationStats: ConversationMetrics) {
+	return {
+		statementCount: conversationStats.statementCount++,
+		statementTurnCount: conversationStats.statementTurnCount++,
+		conversationTurnCount: conversationStats.conversationTurnCount++,
+	};
+}
+
 Deno.test({
 	name: 'LLMConversationInteraction - hydrateMessages',
 	async fn() {
@@ -42,18 +51,32 @@ Deno.test({
 			);
 
 			// Create test messages
+			const conversationStats = {
+				statementCount: 0,
+				statementTurnCount: 0,
+				conversationTurnCount: 0,
+			};
 			const messages: LLMMessage[] = [
 				new LLMMessage(
 					'user',
 					[{ type: 'text', text: `File added: ${testFiles[0]}` }],
+					incrementConversationStats(conversationStats),
 					undefined,
 					undefined,
 					'msg1',
 				),
-				new LLMMessage('assistant', [{ type: 'text', text: 'Acknowledged.' }], undefined, undefined, 'msg2'),
+				new LLMMessage(
+					'assistant',
+					[{ type: 'text', text: 'Acknowledged.' }],
+					incrementConversationStats(conversationStats),
+					undefined,
+					undefined,
+					'msg2',
+				),
 				new LLMMessage(
 					'user',
 					[{ type: 'text', text: `File added: ${testFiles[1]}` }],
+					incrementConversationStats(conversationStats),
 					undefined,
 					undefined,
 					'msg3',
@@ -61,6 +84,7 @@ Deno.test({
 				new LLMMessage(
 					'user',
 					[{ type: 'text', text: `File added: ${testFiles[0]}` }],
+					incrementConversationStats(conversationStats),
 					undefined,
 					undefined,
 					'msg4',

--- a/bui/deno.jsonc
+++ b/bui/deno.jsonc
@@ -16,10 +16,15 @@
 	},
 	"lint": {
 		"rules": {
-			"tags": ["fresh", "recommended"]
+			"tags": [
+				"fresh",
+				"recommended"
+			]
 		}
 	},
-	"exclude": ["**/src/_fresh/*"],
+	"exclude": [
+		"**/src/_fresh/*"
+	],
 	"importMap": "../import_map.json",
 	"compilerOptions": {
 		"jsx": "react-jsx",
@@ -32,8 +37,14 @@
 		"semiColons": true,
 		"singleQuote": true,
 		"proseWrap": "preserve",
-		"include": ["src/", "tests/"],
-		"exclude": ["src/testdata/", "src/fixtures/**/*.ts"]
+		"include": [
+			"src/",
+			"tests/"
+		],
+		"exclude": [
+			"src/testdata/",
+			"src/fixtures/**/*.ts"
+		]
 	},
-	"version": "0.2.3"
+	"version": "0.2.4"
 }

--- a/bui/deno.jsonc
+++ b/bui/deno.jsonc
@@ -16,15 +16,10 @@
 	},
 	"lint": {
 		"rules": {
-			"tags": [
-				"fresh",
-				"recommended"
-			]
+			"tags": ["fresh", "recommended"]
 		}
 	},
-	"exclude": [
-		"**/src/_fresh/*"
-	],
+	"exclude": ["**/src/_fresh/*"],
 	"importMap": "../import_map.json",
 	"compilerOptions": {
 		"jsx": "react-jsx",
@@ -37,14 +32,8 @@
 		"semiColons": true,
 		"singleQuote": true,
 		"proseWrap": "preserve",
-		"include": [
-			"src/",
-			"tests/"
-		],
-		"exclude": [
-			"src/testdata/",
-			"src/fixtures/**/*.ts"
-		]
+		"include": ["src/", "tests/"],
+		"exclude": ["src/testdata/", "src/fixtures/**/*.ts"]
 	},
 	"version": "0.2.3"
 }

--- a/cli/deno.jsonc
+++ b/cli/deno.jsonc
@@ -1,6 +1,6 @@
 {
 	"name": "bb-cli",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"exports": "./src/main.ts",
 	"tasks": {
 		"start": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net src/main.ts",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
 	"name": "bb",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"exports": "./cli/src/main.ts",
 	"tasks": {
 		"tool:check-types-project": "deno task -c ./cli/deno.jsonc check-types && deno task -c ./bui/deno.jsonc check-types && deno task -c ./api/deno.jsonc check-types",

--- a/src/shared/config/configManager.ts
+++ b/src/shared/config/configManager.ts
@@ -478,7 +478,8 @@ export class ConfigManager {
 		// Update the value
 		this.updateNestedValue(current, key, value);
 
-		if (!this.validateGlobalConfig(current)) {
+		if (!this.validateGlobalConfig({ ...current, version: VERSION })) {
+			console.error(current);
 			throw new Error('Invalid global configuration after setting value');
 		}
 
@@ -507,6 +508,14 @@ export class ConfigManager {
 			return false;
 		}
 		//if (!Array.isArray(globalConfig.api.userToolDirectories)) return false;
+		return true;
+	}
+
+	private validateProjectConfig(projectConfig: Partial<ProjectConfigSchema>): boolean {
+		if (!projectConfig.project || typeof projectConfig.project !== 'object') return false;
+		if (typeof projectConfig.project.name !== 'string') return false;
+		if (projectConfig.project.type !== 'git' && projectConfig.project.type !== 'local') return false;
+		//if (!Array.isArray(projectConfig.api.userToolDirectories)) return false;
 		return true;
 	}
 
@@ -556,13 +565,5 @@ export class ConfigManager {
 			}
 		}
 		return value;
-	}
-
-	private validateProjectConfig(projectConfig: Partial<ProjectConfigSchema>): boolean {
-		if (!projectConfig.project || typeof projectConfig.project !== 'object') return false;
-		if (typeof projectConfig.project.name !== 'string') return false;
-		if (projectConfig.project.type !== 'git' && projectConfig.project.type !== 'local') return false;
-		//if (!Array.isArray(projectConfig.api.userToolDirectories)) return false;
-		return true;
 	}
 }

--- a/src/shared/config/configSchema.ts
+++ b/src/shared/config/configSchema.ts
@@ -20,6 +20,7 @@ export interface ApiConfigSchema {
 	usePromptCaching?: boolean;
 	logFile?: string;
 	logLevel: 'debug' | 'info' | 'warn' | 'error';
+	logFileHydration?: boolean;
 	userToolDirectories: string[];
 	toolConfigs: Record<string, unknown>;
 }
@@ -86,6 +87,7 @@ export const defaultGlobalConfig: GlobalConfigSchema = {
 		usePromptCaching: true,
 		logFile: 'api.log',
 		logLevel: 'info',
+		logFileHydration: false,
 		toolConfigs: {},
 		userToolDirectories: ['./tools'], // This will be resolved to an absolute path by ConfigManager
 		maxTurns: 25, // Maximum number of turns in a conversation
@@ -123,6 +125,7 @@ export const defaultProjectConfig: ProjectConfigSchema = {
 		usePromptCaching: true,
 		logFile: 'api.log',
 		logLevel: 'info',
+		logFileHydration: false,
 		toolConfigs: {},
 		userToolDirectories: ['./tools'], // This will be resolved to an absolute path by ConfigManager
 	},

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.2.3";
+export const VERSION = "0.2.4";


### PR DESCRIPTION
- set apiUseTls to false during project init if certs could not be created
- fixed message hydration to keep last two versions of each file
- changed prompt caching to add cache points of three most recent messages with hydrated files
- removed "statement objective" on first statement, in favour of "conversation objective"
- fixed statement counts in messages.jsonl
