### PR TITLE
import fix

### DIFF
--- a/api/src/llms/tools/loadResources.tool/tests/contentFormat.test.ts
+++ b/api/src/llms/tools/loadResources.tool/tests/contentFormat.test.ts
@@ -82,4 +82,3 @@ Deno.test({
 	sanitizeResources: false,
 	sanitizeOps: false,
 });
-

--- a/bui/src/fresh.config.ts
+++ b/bui/src/fresh.config.ts
@@ -16,7 +16,7 @@ import { buiFileLogger } from 'bui/utils/fileLogger.ts';
 //import { supabaseAuthPlugin } from './plugins/supabaseAuth.ts';
 //import { authPlugin } from './plugins/auth.plugin.ts';
 import { stateConfigPlugin } from './plugins/stateConfig.plugin.ts';
-import type { FreshAppState } from 'bui/types/state.types.ts';
+import type { FreshAppState } from 'bui/types/state.ts';
 
 // CWD is set by `bb` in Deno.Command, or implicitly set by user if calling bb-bui directly
 

--- a/bui/src/plugins/auth.plugin.ts
+++ b/bui/src/plugins/auth.plugin.ts
@@ -1,9 +1,8 @@
 import type { FreshContext, Plugin } from '$fresh/server.ts';
 import type { BuiConfig } from 'shared/config/types.ts';
-import 'bui/types/state.types.ts'; // Augment Fresh context state types
 import { initializeAuthState, useAuthState } from '../hooks/useAuthState.ts';
 //import { IS_BROWSER } from '$fresh/runtime.ts';
-import { FreshAppState } from 'bui/types/state.ts'; // Augment Fresh context state types
+import type { FreshAppState } from 'bui/types/state.ts';
 
 export const authPlugin = (buiConfig: BuiConfig): Plugin => {
 	try {

--- a/bui/src/plugins/stateConfig.plugin.ts
+++ b/bui/src/plugins/stateConfig.plugin.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareHandler, MiddlewareHandlerContext, Plugin } from '$fresh/server.ts';
-import type { FreshAppState } from 'bui/types/state.types.ts';
+import type { FreshAppState } from 'bui/types/state.ts';
 
 export const stateConfigPlugin = (initialState: FreshAppState): Plugin<FreshAppState> => {
 	const handler: MiddlewareHandler<FreshAppState> = async (_req, ctx: MiddlewareHandlerContext<FreshAppState>) => {

--- a/bui/src/routes/api/v1/oauth/google/config.ts
+++ b/bui/src/routes/api/v1/oauth/google/config.ts
@@ -1,5 +1,5 @@
 import { type FreshContext, Handlers } from '$fresh/server.ts';
-import type { FreshAppState } from 'bui/types/state.types.ts';
+import type { FreshAppState } from 'bui/types/state.ts';
 
 /**
  * Get Google OAuth configuration for the BUI

--- a/bui/src/routes/api/v1/oauth/google/token.ts
+++ b/bui/src/routes/api/v1/oauth/google/token.ts
@@ -1,5 +1,5 @@
 import { type FreshContext, Handlers } from '$fresh/server.ts';
-import type { FreshAppState } from 'bui/types/state.types.ts';
+import type { FreshAppState } from 'bui/types/state.ts';
 
 /**
  * Handle Google OAuth token operations:


### PR DESCRIPTION
### Added

- read/write support for editing Notion documents (saas only)
- read/write support for editing GoogleDocs documents (saas only)
- dynamic loading for third-party datasources
- integration tests for datasources

### Changed

- remaining tools updated to use datasource accessors
- deprecated searchAndReplace and rewriteResource tools in favour of editResource and writeResource
- support for contentFormat and editTypes to all resource tools

### Fixed

- save in-progess prompt when navigating within app
- validate content parts returned from LLM
